### PR TITLE
Fix negative level issue in html-format

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,8 @@ function format(/** @type {string} */ html, indent = "  ", width = 80) {
       const tagName = token.groups.endTagName.toLowerCase();
       if (tagName == specialElement) specialElement = null;
       if (!specialElement) {
-        --level;
+		--level;
+		if (level < 0) level = 0;
         addOutput(`</${tagName}>`);
       }
     }

--- a/index.js
+++ b/index.js
@@ -131,8 +131,8 @@ function format(/** @type {string} */ html, indent = "  ", width = 80) {
       const tagName = token.groups.endTagName.toLowerCase();
       if (tagName == specialElement) specialElement = null;
       if (!specialElement) {
-		--level;
-		if (level < 0) level = 0;
+        --level;
+        if (level < 0) level = 0;
         addOutput(`</${tagName}>`);
       }
     }


### PR DESCRIPTION
When the input html is malformed and the number of end tags exceed the number of opening tags, `level` will go negative. That will cause `spanLevel` to become negative, causing `indent.repeat(spanLevel)` to throw a `RangeError`.

By making sure `level` clamps at 0, this i avoided.